### PR TITLE
Set User-Agent to WhatsApp so firebase dynamic links work

### DIFF
--- a/lib/url_preview_card.dart
+++ b/lib/url_preview_card.dart
@@ -139,7 +139,7 @@ class _UrlPreviewCardState extends State<UrlPreviewCard> {
       });
     }
 
-    var response = await get(widget.url);
+    var response = await get(widget.url, headers: {'User-Agent': 'WhatsApp'});
     if (!this.mounted) return;
 
     if (response.statusCode != 200) {


### PR DESCRIPTION
Pretty certain this applies to more than just Firebase Dynamic Links, but that's the particular issue I needed to fix.

Just followed the Signal source code in using WhatsApp as the user agent.